### PR TITLE
Fix build error and Add docker environment

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -171,3 +171,16 @@ import morelogging
 let log = newStdoutLogger(fmtStr="$time ")
 log.info("hello world")
 ----
+
+=== Development with Docker
+
+You can easily run tests if you have 'docker' and 'docker-compose'.
+You don't have to setup dependencies (libsystemd-dev) on your host PC.
+
+To get up and running:
+
+```bash
+cd docker
+docker-compose build
+docker-compose up
+```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM nimlang/nim:1.2.6-ubuntu
+
+RUN apt-get update -yqq \
+    && apt-get install -y --no-install-recommends \
+               libsystemd-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+
+# install dependencies
+RUN nimble install -Y

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.7"
+
+services:
+  morelogging:
+    build:
+      context: ../
+      dockerfile: ./docker/Dockerfile
+    volumes:
+      - "../:/app"
+    entrypoint: nim c -p:. -r tests/test_morelogging.nim

--- a/morelogging.nimble
+++ b/morelogging.nimble
@@ -7,7 +7,7 @@ license       = "LGPLv3"
 
 # Dependencies
 
-requires "nim >= 0.15.0", "zip"
+requires "nim >= 0.15.0", "zip#5af653e18b6f0d7871e0113751823fbf4168a937"
 
 
 task functional_tests, "Functional tests":


### PR DESCRIPTION
Could not build and test.

```bash
⟩ nim c -p:. -r tests/test_morelogging.nim
/home/vagrant/src/github.com/jiro4989/nim-morelogging/morelogging.nim(308, 23) Error: type mismatch: got <GzFile, pointer, int>
but expected one of:
proc gzwrite(thefile: GzFile; buf: pointer; length: cuint): cint
  first type mismatch at position: 3
  required type for length: cuint
  but expression 'src.size' is of type: int

expression: zlib.gzwrite(dst, src.mem, src.size)
```

The reason is that zip package was changed. (https://github.com/nim-lang/zip/commit/987e9c38068fb33a0abd8bff47727750065b29e9#diff-aa39855f892de3c9762b83ecdfbae8e4R126)

So I set revision to zip of morelogging.nimble.

> requires "nim >= 0.15.0", "zip#5af653e18b6f0d7871e0113751823fbf4168a937"

And I add docker environment.
We don't have to setup `libsystemd-dev` package on our host PC.
